### PR TITLE
Attempt to vend vec_2d code to cuproj and use in cuprojshim

### DIFF
--- a/cpp/cuproj/include/cuproj/vec_2d.cuh
+++ b/cpp/cuproj/include/cuproj/vec_2d.cuh
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <ostream>
+
+namespace cuproj {
+
+/**
+ * @addtogroup types
+ * @{
+ */
+
+/**
+ * @brief A generic 2D vector type.
+ *
+ * This is the base type used in cuproj for both Longitude/Latitude (LonLat) coordinate pairs and
+ * Cartesian (X/Y) coordinate pairs. For LonLat pairs, the `x` member represents Longitude, and `y`
+ * represents Latitude.
+ *
+ * @tparam T the base type for the coordinates
+ */
+template <typename T>
+class alignas(2 * sizeof(T)) vec_2d {
+ public:
+  using value_type = T;
+  value_type x;
+  value_type y;
+
+ private:
+  /**
+   * @brief Output stream operator for `vec_2d<T>` for human-readable formatting
+   */
+  friend std::ostream& operator<<(std::ostream& os, cuproj::vec_2d<T> const& vec)
+  {
+    return os << "(" << vec.x << "," << vec.y << ")";
+  }
+
+  /**
+   * @brief Compare two 2D vectors for equality.
+   */
+  friend bool __host__ __device__ operator==(vec_2d<T> const& lhs, vec_2d<T> const& rhs)
+  {
+    return lhs.x == rhs.x && lhs.y == rhs.y;
+  }
+
+  /**
+   * @brief Element-wise addition of two 2D vectors.
+   */
+  friend vec_2d<T> __host__ __device__ operator+(vec_2d<T> const& a, vec_2d<T> const& b)
+  {
+    return vec_2d<T>{a.x + b.x, a.y + b.y};
+  }
+
+  /**
+   * @brief Element-wise subtraction of two 2D vectors.
+   */
+  friend vec_2d<T> __host__ __device__ operator-(vec_2d<T> const& a, vec_2d<T> const& b)
+  {
+    return vec_2d<T>{a.x - b.x, a.y - b.y};
+  }
+
+  /**
+   * @brief Invert a 2D vector.
+   */
+  friend vec_2d<T> __host__ __device__ operator-(vec_2d<T> const& a)
+  {
+    return vec_2d<T>{-a.x, -a.y};
+  }
+
+  /**
+   * @brief Scale a 2D vector by a factor @p r.
+   */
+  friend vec_2d<T> __host__ __device__ operator*(vec_2d<T> vec, T const& r)
+  {
+    return vec_2d<T>{vec.x * r, vec.y * r};
+  }
+
+  /**
+   * @brief Scale a 2d vector by ratio @p r.
+   */
+  friend vec_2d<T> __host__ __device__ operator*(T const& r, vec_2d<T> vec) { return vec * r; }
+
+  /**
+   * @brief Translate a 2D point
+   */
+  friend vec_2d<T>& __host__ __device__ operator+=(vec_2d<T>& a, vec_2d<T> const& b)
+  {
+    a.x += b.x;
+    a.y += b.y;
+    return a;
+  }
+
+  /**
+   * @brief Translate a 2D point
+   */
+  friend vec_2d<T>& __host__ __device__ operator-=(vec_2d<T>& a, vec_2d<T> const& b)
+  {
+    return a += -b;
+  }
+
+  /**
+   * @brief Less than operator for two 2D points.
+   *
+   * Orders two points first by x, then by y.
+   */
+  friend bool __host__ __device__ operator<(vec_2d<T> const& lhs, vec_2d<T> const& rhs)
+  {
+    if (lhs.x < rhs.x)
+      return true;
+    else if (lhs.x == rhs.x)
+      return lhs.y < rhs.y;
+    return false;
+  }
+
+  /**
+   * @brief Greater than operator for two 2D points.
+   */
+  friend bool __host__ __device__ operator>(vec_2d<T> const& lhs, vec_2d<T> const& rhs)
+  {
+    return rhs < lhs;
+  }
+
+  /**
+   * @brief Less than or equal to operator for two 2D points.
+   */
+  friend bool __host__ __device__ operator<=(vec_2d<T> const& lhs, vec_2d<T> const& rhs)
+  {
+    return !(lhs > rhs);
+  }
+
+  /**
+   * @brief Greater than or equal to operator for two 2D points.
+   */
+  friend bool __host__ __device__ operator>=(vec_2d<T> const& lhs, vec_2d<T> const& rhs)
+  {
+    return !(lhs < rhs);
+  }
+};
+
+// Deduction guide enables CTAD
+template <typename T>
+vec_2d(T x, T y) -> vec_2d<T>;
+
+/**
+ * @brief Compute dot product of two 2D vectors.
+ */
+template <typename T>
+T __host__ __device__ dot(vec_2d<T> const& a, vec_2d<T> const& b)
+{
+  return a.x * b.x + a.y * b.y;
+}
+
+/**
+ * @brief Compute 2D determinant of a 2x2 matrix with column vectors @p a and @p b.
+ */
+template <typename T>
+T __host__ __device__ det(vec_2d<T> const& a, vec_2d<T> const& b)
+{
+  return a.x * b.y - a.y * b.x;
+}
+
+/**
+ * @brief Return a new vec_2d made up of the minimum x- and y-components of two input vec_2d values.
+ */
+template <typename T>
+vec_2d<T> __host__ __device__ box_min(vec_2d<T> const& a, vec_2d<T> const& b)
+{
+#ifdef __CUDA_ARCH__
+  return vec_2d<T>{::min(a.x, b.x), ::min(a.y, b.y)};
+#else
+  return vec_2d<T>{std::min(a.x, b.x), std::min(a.y, b.y)};
+#endif
+}
+
+/**
+ * @brief Return a new vec_2d made up of the minimum x- and y-components of two input vec_2d values.
+ */
+template <typename T>
+vec_2d<T> __host__ __device__ box_max(vec_2d<T> const& a, vec_2d<T> const& b)
+{
+#ifdef __CUDA_ARCH__
+  return vec_2d<T>{::max(a.x, b.x), ::max(a.y, b.y)};
+#else
+  return vec_2d<T>{std::max(a.x, b.x), std::max(a.y, b.y)};
+#endif
+}
+
+/**
+ * @brief Compute the midpoint of `first` and `second`.
+ */
+template <typename T>
+vec_2d<T> __host__ __device__ midpoint(vec_2d<T> const& first, vec_2d<T> const& second)
+{
+  return (first + second) * T{0.5};
+}
+
+/**
+ * @} // end of doxygen group
+ */
+
+}  // namespace cuproj

--- a/cpp/src/distance/haversine.cu
+++ b/cpp/src/distance/haversine.cu
@@ -54,7 +54,7 @@ struct haversine_functor {
     if (a_lon.is_empty()) { return cudf::empty_like(a_lon); }
 
     auto mask_policy = cudf::mask_allocation_policy::NEVER;
-    auto result      = cudf::allocate_like(a_lon, a_lon.size(), mask_policy, mr);
+    auto result      = cudf::allocate_like(a_lon, a_lon.size(), mask_policy, stream, mr);
 
     auto lonlat_a = cuspatial::make_vec_2d_iterator(a_lon.begin<T>(), a_lat.begin<T>());
     auto lonlat_b = cuspatial::make_vec_2d_iterator(b_lon.begin<T>(), b_lat.begin<T>());

--- a/cpp/src/trajectory/derive_trajectories.cu
+++ b/cpp/src/trajectory/derive_trajectories.cu
@@ -47,10 +47,10 @@ struct derive_trajectories_dispatch {
   {
     auto cols = std::vector<std::unique_ptr<cudf::column>>{};
     cols.reserve(4);
-    cols.push_back(cudf::allocate_like(object_id, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(x, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(y, cudf::mask_allocation_policy::NEVER, mr));
-    cols.push_back(cudf::allocate_like(timestamp, cudf::mask_allocation_policy::NEVER, mr));
+    cols.push_back(cudf::allocate_like(object_id, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(x, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(y, cudf::mask_allocation_policy::NEVER, stream, mr));
+    cols.push_back(cudf::allocate_like(timestamp, cudf::mask_allocation_policy::NEVER, stream, mr));
 
     auto points_begin     = thrust::make_zip_iterator(x.begin<T>(), y.begin<T>());
     auto points_out_begin = thrust::make_zip_iterator(cols[1]->mutable_view().begin<T>(),

--- a/python/cuproj/cuproj/_lib/cpp/cuprojshim.pxd
+++ b/python/cuproj/cuproj/_lib/cpp/cuprojshim.pxd
@@ -1,0 +1,11 @@
+from cuproj._lib.cpp.projection cimport projection
+from cuproj._lib.cpp.operation cimport direction
+
+cdef extern from "cuprojshim.hpp" namespace "cuproj" nogil:
+    void transform(
+        projection[double],
+        vec_2d*,
+        vec_2d*,
+        size_t,
+        direction
+    )

--- a/python/cuproj/cuproj/cuprojshim/CMakeLists.txt
+++ b/python/cuproj/cuproj/cuprojshim/CMakeLists.txt
@@ -53,7 +53,7 @@ rapids_cuda_init_runtime(USE_STATIC ${CUDA_STATIC_RUNTIME})
 # * set other CUDA compilation flags
 include(../../../../cpp/cuproj/cmake/modules/ConfigureCUDA.cmake)
 
-add_library(cuprojshim STATIC cuprojshim.cu)
+add_library(cuprojshim STATIC src/cuprojshim.cu)
 
 set_target_properties(cuprojshim
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
@@ -80,10 +80,11 @@ target_compile_definitions(cuprojshim
 # Specify include paths for the current target and dependents
 target_include_directories(cuprojshim
            PUBLIC      "$<BUILD_INTERFACE:${CUPROJ_SOURCE_DIR}/include>"
+           PRIVATE     "$<BUILD_INTERFACE:${CUPROJSHIM_SOURCE_DIR}/include>"
            PRIVATE     "$<BUILD_INTERFACE:${CUPROJSHIM_SOURCE_DIR}>"
            INTERFACE   "$<INSTALL_INTERFACE:include>")
 
-target_link_libraries(cuprojshim cuproj rmm::rmm cuspatial::cuspatial)
+target_link_libraries(cuprojshim cuproj rmm::rmm)
 
 # Per-thread default stream
 if(PER_THREAD_DEFAULT_STREAM)

--- a/python/cuproj/cuproj/cuprojshim/cuprojshim.cu
+++ b/python/cuproj/cuproj/cuprojshim/cuprojshim.cu
@@ -1,13 +1,10 @@
 #include <cuproj/projection.cuh>
-
-#include <cuspatial/geometry/vec_2d.hpp>
+#include <cuproj/vec_2d.cuh>
 
 namespace cuprojshim {
 
-template <typename T> using coordinate = cuspatial::vec_2d<T>;
-
-void transform(cuproj::projection<coordinate<double>> const &proj,
-               coordinate<double> *xy_in, coordinate<double> *xy_out,
+void transform(cuproj::projection<cuproj::vec_2d<double>> const &proj,
+               cuproj::vec_2d<double> *xy_in, cuproj::vec_2d<double> *xy_out,
                std::size_t n, cuproj::direction dir) {
   proj.transform(xy_in, xy_in + n, xy_out, dir);
 }

--- a/python/cuproj/cuproj/cuprojshim/include/cuprojshim.hpp
+++ b/python/cuproj/cuproj/cuprojshim/include/cuprojshim.hpp
@@ -1,0 +1,10 @@
+#include <cuproj/projection.cuh>
+#include <cuproj/vec_2d.cuh>
+
+namespace cuprojshim {
+
+void transform(cuproj::projection<cuproj::vec_2d<double>> const &proj,
+               cuproj::vec_2d<double> *xy_in, cuproj::vec_2d<double> *xy_out,
+               std::size_t n, cuproj::direction dir);
+
+} // namespace cuprojshim

--- a/python/cuproj/cuproj/cuprojshim/src/cuprojshim.cu
+++ b/python/cuproj/cuproj/cuprojshim/src/cuprojshim.cu
@@ -1,5 +1,4 @@
-#include <cuproj/projection.cuh>
-#include <cuproj/vec_2d.cuh>
+#include <cuprojshim.hpp>
 
 namespace cuprojshim {
 


### PR DESCRIPTION
- Add streams to allocate_like call
- Vended vec_2d from cuspatial
- restructure cuproj folder structures and update cuproj cython bindings accordingly

As title.

I went down the vending code route for a little bit and still run into blockers. There is device code in vec_2d class that's used in cuproj library, so we need to vend the device code as well. This makes vec_2d not completely a host only library and makes whichever interface that we want to expose in cuprojshim not host-only code either. And whichever cython interface that contains device code will throw the build system off.
We need to think of a way to hide away the device code for vec_2d or move the device code of vec_2d to outside of the class (as standalone functions, albeit it might be slower to compile due to ADL)
